### PR TITLE
Clean up log search output

### DIFF
--- a/warp/website/public/wdc-config.yaml
+++ b/warp/website/public/wdc-config.yaml
@@ -26,7 +26,7 @@ log_patterns_by_issue:
       "Possible Revoked Device":
         search_term:
           - 'code: 2019, message: "missing device id"'
-  - search_file: ps.txt
+  - search_file: ps.txt, processes.txt
     issue_type:
       "Firewall":
         search_term:


### PR DESCRIPTION
allow comma separated files in search file
refactor evidence to be in reverse order
limit evidence to 5 entries per issue type